### PR TITLE
Activate docker analyzer

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -25,3 +25,7 @@ dependency_file_paths = ["requirements.txt"]
 [[analyzers]]
 name = "test-coverage"
 enabled = true
+
+[[analyzers]]
+name = "docker"
+enabled = true


### PR DESCRIPTION
This PR activates the DeepSource dockerfile analyzer on your repository to ensure best practices and methods are followed to build efficient docker images.

Let me know if you have any more queries. 